### PR TITLE
Feat: export API Classes for testing purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-buildkite",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@
  */
 export * from './plugin';
 export * from './components/Router';
+export * from './api';


### PR DESCRIPTION
Hello,
in order to write EntityPage tests I was forced to export API Classes from BuildKite plugin.  This PR also bump plugin version so I it will be possible to publish it on NPM.